### PR TITLE
Fix missing README.rst on pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 from distutils.core import setup
 
 setup(
@@ -7,7 +8,7 @@ setup(
     scripts=['bin/treehash'],
     license="Simplified BSD",
     description="Tree Hash Calculator",
-    long_description=open('README.rst').read(),
+    long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst')).read(),
     url="http://github.com/jdswinbank/treehash",
     author="John Swinbank",
     author_email="john@treehash.swinbank.org"

--- a/treehash/treehash.py
+++ b/treehash/treehash.py
@@ -29,6 +29,8 @@ class TreeHash(object):
         extra = self.pending.read()
         if extra:
             to_recurse.append(self.algo(extra))
+	elif len(to_recurse) == 0:
+          to_recurse.append(self.algo(""))
         return recursive_hash(to_recurse)
 
     def update(self, data):


### PR DESCRIPTION
When I do "pip install treehash" inside a virtualend, I get this error:

  Using cached TreeHash-1.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/private/var/folders/5h/sz3xv01d02dc3xvxtxwgcr_w0000gp/T/pip-build-BL9jzk/treehash/setup.py", line 9, in <module>
        long_description=open('README.rst').read(),
    IOError: [Errno 2] No such file or directory: 'README.rst'

The script running setup.py must be running from a different directory. README.rst sits next to setup.py, so using the path of the setup file solves the problem:

$ pip install git+git://github.com/lazerdye/treehash.git
Collecting git+git://github.com/lazerdye/treehash.git
  Cloning git://github.com/lazerdye/treehash.git to /var/folders/5h/sz3xv01d02dc3xvxtxwgcr_w0000gp/T/pip-xbJHN7-build
Installing collected packages: TreeHash
  Running setup.py install for TreeHash
Successfully installed TreeHash-1.0
