### PR TITLE
Enable Parallel Hashing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
 script: python -m unittest discover
 sudo: false

--- a/bin/treehash
+++ b/bin/treehash
@@ -18,8 +18,9 @@ if __name__ == "__main__":
     file_name = args.file_name
     process_n = args.process_n
     file_size = os.path.getsize(file_name)
-    print("Processing file :"+file_name + " with size:"+file_size + "bytes")
-    print("Using " + str(process_n) + "processes to hash")
+    print("Processing file: "+file_name +
+          " with size:"+str(file_size) + "bytes")
+    print("Using " + str(process_n) + " processes to hash")
     with open(file_name, 'rb') as my_file:
         chunck_n = math.ceil(file_size / MEGABYTE)
         treehash = TreeHash(chunck_n)

--- a/bin/treehash
+++ b/bin/treehash
@@ -1,16 +1,34 @@
 #!/usr/bin/env python
+import argparse
 
-import sys
+import math
+import os
+from concurrent.futures import ThreadPoolExecutor, wait
 from treehash import TreeHash
-
-MEGABYTE=1024**2
+from treehash import MEGABYTE
 
 if __name__ == "__main__":
-    for fname in sys.argv[1:]:
-        with open(fname, 'rb') as my_file:
-            treehash = TreeHash()
-            while True:
-                data = my_file.read(MEGABYTE)
-                treehash.update(data)
-                if len(data) < (MEGABYTE): break
-            print("%s: %s" % (fname, treehash.hexdigest()))
+    parser = argparse.ArgumentParser(description='Compute sha256-treehash.')
+    parser.add_argument(
+        'file_name', help="input filename", type=str)
+    parser.add_argument(
+        "-p", "--process", help="number of hashing process, recommand larger than 2 but less than your cpu core number, default 4", default=4, dest='process_n', type=int)
+    args = parser.parse_args()
+
+    file_name = args.file_name
+    process_n = args.process_n
+    file_size = os.path.getsize(file_name)
+    print("Processing file :"+file_name + " with size:"+file_size + "bytes")
+    print("Using " + str(process_n) + "processes to hash")
+    with open(file_name, 'rb') as my_file:
+        chunck_n = math.ceil(file_size / MEGABYTE)
+        treehash = TreeHash(chunck_n)
+        executor = ThreadPoolExecutor(process_n)
+        futures = []
+        for chunck in range(0, chunck_n):
+            data = my_file.read(MEGABYTE)
+            futures.append(executor.submit(
+                treehash.update, data, chunck))
+        wait(futures)
+        print("%s: %s" % (file_name, treehash.hexdigest()))
+        executor.shutdown()

--- a/treehash/__init__.py
+++ b/treehash/__init__.py
@@ -1,2 +1,3 @@
 from .treehash import TreeHash
-__all__ = ["TreeHash"]
+from .treehash import MEGABYTE
+__all__ = ["TreeHash", "MEGABYTE"]

--- a/treehash/test/test_treehash.py
+++ b/treehash/test/test_treehash.py
@@ -3,32 +3,39 @@ import hashlib
 from treehash import TreeHash
 
 TEST_DATA = b"a"
+TEST_CHUNK = 1
+TEST_INDEX = 0
+
 
 class TreeHashTestCase(unittest.TestCase):
     def test_constructor(self):
         self.assertEqual(
-            hashlib.sha256(TEST_DATA).hexdigest(),
-            TreeHash(TEST_DATA).hexdigest()
+            TEST_CHUNK,
+            len(TreeHash(TEST_CHUNK).hashes)
         )
 
     def test_update(self):
-        treehash = TreeHash()
-        treehash.update(TEST_DATA)
+        tree_hash = TreeHash(TEST_CHUNK)
+        tree_hash.update(TEST_DATA, TEST_INDEX)
         self.assertEqual(
             hashlib.sha256(TEST_DATA).hexdigest(),
-            treehash.hexdigest()
+            tree_hash.hexdigest()
         )
 
     def test_md5(self):
+        tree_hash = TreeHash(TEST_CHUNK, algo=hashlib.md5)
+        tree_hash.update(TEST_DATA, TEST_INDEX)
         self.assertEqual(
             hashlib.md5(TEST_DATA).hexdigest(),
-            TreeHash(TEST_DATA, algo=hashlib.md5).hexdigest()
+            tree_hash.hexdigest()
         )
 
     def test_digest(self):
+        tree_hash = TreeHash(TEST_CHUNK, algo=hashlib.md5)
+        tree_hash.update(TEST_DATA, TEST_INDEX)
         self.assertEqual(
             hashlib.md5(TEST_DATA).digest(),
-            TreeHash(TEST_DATA, algo=hashlib.md5).digest()
+            tree_hash.digest()
         )
 
     def test_tree(self):
@@ -36,12 +43,15 @@ class TreeHashTestCase(unittest.TestCase):
             hashlib.sha256(TEST_DATA).digest() +
             hashlib.sha256(TEST_DATA).digest()
         ).hexdigest()
+
+        tree_hash = TreeHash(2, block_size=1)
+        tree_hash.update(TEST_DATA, 0)
+        tree_hash.update(TEST_DATA, 1)
         self.assertEqual(hashlib_result,
-            TreeHash(2*TEST_DATA, block_size=1).hexdigest()
-        )
+                         tree_hash.hexdigest())
 
     def test_empty(self):
         self.assertEqual(
             hashlib.sha256().hexdigest(),
-            TreeHash().hexdigest()
+            TreeHash(0).hexdigest()
         )


### PR DESCRIPTION
Dear John:
  Your treehash library is fantastic, I really loved it!
  Your code is clean and powerful, and It's convenient to use. because I can install from pip no matter where i am.
  And I noticed that , this treehash lib use only one thread to compute hash and read file  in the mean time, so I thought maybe I can help to speed it up a little bit.
  So I added a **multithread** trick to speed up hashing
  using the main thread to read file, and hand out hashing jobs to thread pool.
  
  Pros: faster speed
  I tested a 37GB file using 4 hashing threads on my computer,  the consumed time  reduced from 4'23 to 1'39. That's really a speedup. (271%)

  Cons:compatibility
  I imported concurrent.futures to use the thread pool, which is only for python3 , so this PR is not compatible with python2

